### PR TITLE
fix: Grant permissions on all URLs in Firefox 59+

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
 		"96": "data/icons/enabled-96.png"
 	},
 	"permissions": [
-		"<all_urls>",
+		"*://*/",
 		"storage",
 		"activeTab",
 		"tabs"


### PR DESCRIPTION
Fixes #37 in my tests.