### PR TITLE
V3 - Settings Buttons to Import/Export settings

### DIFF
--- a/background.js
+++ b/background.js
@@ -281,13 +281,14 @@ function handlePanelMessage(message, tab) {
     }
 }
 
+//save site settings to local storage and 
+//assign new values to global site settings variables
 function replaceSiteSettings(newSettings){
     browser.storage.local.get().then((settings) => {
         // reset storage if nothing is stored so far
         if (!settings || (Object.keys(settings).length === 0 && settings.constructor === Object)) {
             resetStorage();
         } else {
-            //console.log(newSettings)
             browser.storage.local.set(newSettings)
             .then(()=>{
                 /* Site configuration lists */

--- a/background.js
+++ b/background.js
@@ -271,9 +271,35 @@ function handlePanelMessage(message, tab) {
                 });
             }
         }
+        case "replaceSiteSettings":{
+            newSettings = message.newSettings
+            if(newSettings){
+                replaceSiteSettings(newSettings)
+            }
+            
+        }
     }
 }
 
+function replaceSiteSettings(newSettings){
+    browser.storage.local.get().then((settings) => {
+        // reset storage if nothing is stored so far
+        if (!settings || (Object.keys(settings).length === 0 && settings.constructor === Object)) {
+            resetStorage();
+        } else {
+            //console.log(newSettings)
+            browser.storage.local.set(newSettings)
+            .then(()=>{
+                /* Site configuration lists */
+                alwaysDisableSites = newSettings.whiteSites;
+                alwaysEnableSites = newSettings.alwaysEnableSites;
+                /* Set default classics */
+                classicSiteList = newSettings.classicSiteList;
+            })
+        }
+
+    });
+}
 function getStyleFileForUrl(tabUrl) {
     /* Check if file is local file */
     if (tabUrl.indexOf("file://") > -1 && !localFiles)

--- a/data/css/owl_preferences.css
+++ b/data/css/owl_preferences.css
@@ -26,9 +26,14 @@ input[type="checkbox"]:active {
     outline: none;
 }
 
-#openSiteConfig {
+#openSiteConfig, 
+#exportSettings,
+#importSettings{
     background-color: #fbfbfb;
     border: 1px solid #c1c1c1;
+}
+#importSettingsInput{
+    display:none
 }
 
 #openSiteConfig:hover,

--- a/data/js/owl_preferences.js
+++ b/data/js/owl_preferences.js
@@ -106,7 +106,7 @@
             const reader = new FileReader();      
             reader.onload = function(e) {
               let text = JSON.parse(e.target.result);
-              console.log(text.whiteSites)
+              changeSiteSettings(text)
             }
             reader.onerror = function(err) {
               console.log(
@@ -118,6 +118,21 @@
   
             reader.readAsText(file);
         }
+        function changeSiteSettings(new_settings){
+            browser.storage.local.get().then((settings) => {
+                // reset storage if nothing is stored so far
+                if (!settings || (Object.keys(settings).length === 0 && settings.constructor === Object)) {
+                    resetStorage();
+                } else {
+                    browser.storage.local.set({
+                        whiteSites: new_settings.whiteSites,
+                        alwaysEnableSites:new_settings.alwaysEnableSites,
+                        classicSiteList:new_settings.classicSiteList
+                    });
+                }
+
+        });
+    }
 
     });
 }());

--- a/data/js/owl_preferences.js
+++ b/data/js/owl_preferences.js
@@ -51,6 +51,73 @@
                 url: "configure_sites.html"
             });
         });
+        const saveDataToFile = function(data, fileName, properties) {
+            window.URL = window.URL || window.webkitURL;
+            var file = new File(data, fileName, properties),
+              link = document.createElement('a');
+            link.href = window.URL.createObjectURL(file);
+            link.download = fileName;
+            document.body.appendChild(link);
+            link.click();
+            window.URL.revokeObjectURL(link.href);// possible problem here
+            document.body.removeChild(link)
+          };
+        //create on click listener for export setting button
+        $("#exportSettings").click(function() {
+        
+            browser.storage.local.get().then((settings) => {
+                // reset storage if nothing is stored so far
+                if (!settings || (Object.keys(settings).length === 0 && settings.constructor === Object)) {
+                    resetStorage();
+                } else {
+                    const fileName = 'owl_settings.json',
+                    properties = {
+                    type: 'octet/stream'
+                    },
+                    data = [JSON.stringify({
+                        whiteSites:settings.whiteSites,
+                        alwaysEnableSites:settings.alwaysEnableSites,
+                        classicSiteList:settings.classicSiteList
+                    })];
+                    saveDataToFile(data, fileName, properties);
+                    console.log('save')
+                }
+                
+            }, (err)=>{
+                console.log(err)
+            });
+        
+            
+        });
+
+        $("#importSettings").change(function(event){
+            const filesList = event.target.files;
+            //console.log('print this',filesList[0])
+            if(filesList.length===1){
+                const file = filesList[0]
+                console.log(file)
+                readJSON(file)
+
+            }
+        })
+
+
+        function readJSON(file) {
+            const reader = new FileReader();      
+            reader.onload = function(e) {
+              let text = JSON.parse(e.target.result);
+              console.log(text.whiteSites)
+            }
+            reader.onerror = function(err) {
+              console.log(
+                  err, 
+                  err.loaded, 
+                  err.loaded === 0, 
+                  file);
+            }
+  
+            reader.readAsText(file);
+        }
 
     });
 }());

--- a/data/js/owl_preferences.js
+++ b/data/js/owl_preferences.js
@@ -105,8 +105,12 @@
         function readJSON(file) {
             const reader = new FileReader();      
             reader.onload = function(e) {
-              let text = JSON.parse(e.target.result);
-              changeSiteSettings(text)
+                let newSettings = JSON.parse(e.target.result);
+                console.log(newSettings)
+                browser.runtime.sendMessage({
+                    intent: "replaceSiteSettings",
+                    newSettings: newSettings
+                });
             }
             reader.onerror = function(err) {
               console.log(
@@ -118,21 +122,7 @@
   
             reader.readAsText(file);
         }
-        function changeSiteSettings(new_settings){
-            browser.storage.local.get().then((settings) => {
-                // reset storage if nothing is stored so far
-                if (!settings || (Object.keys(settings).length === 0 && settings.constructor === Object)) {
-                    resetStorage();
-                } else {
-                    browser.storage.local.set({
-                        whiteSites: new_settings.whiteSites,
-                        alwaysEnableSites:new_settings.alwaysEnableSites,
-                        classicSiteList:new_settings.classicSiteList
-                    });
-                }
 
-        });
-    }
 
     });
 }());

--- a/data/js/owl_preferences.js
+++ b/data/js/owl_preferences.js
@@ -51,17 +51,7 @@
                 url: "configure_sites.html"
             });
         });
-        const saveDataToFile = function(data, fileName, properties) {
-            window.URL = window.URL || window.webkitURL;
-            var file = new File(data, fileName, properties),
-              link = document.createElement('a');
-            link.href = window.URL.createObjectURL(file);
-            link.download = fileName;
-            document.body.appendChild(link);
-            link.click();
-            window.URL.revokeObjectURL(link.href);// possible problem here
-            document.body.removeChild(link)
-          };
+       
         //create on click listener for export setting button
         $("#exportSettings").click(function() {
         
@@ -92,17 +82,14 @@
 
         $("#importSettings").change(function(event){
             const filesList = event.target.files;
-            //console.log('print this',filesList[0])
             if(filesList.length===1){
                 const file = filesList[0]
-                console.log(file)
-                readJSON(file)
-
+                importSettingsFromJSONFile(file)
             }
         })
 
-
-        function readJSON(file) {
+        //Import site settings from a JSON file
+        function importSettingsFromJSONFile(file) {
             const reader = new FileReader();      
             reader.onload = function(e) {
                 let newSettings = JSON.parse(e.target.result);
@@ -122,7 +109,18 @@
   
             reader.readAsText(file);
         }
-
+        //save locally created data to file
+        const saveDataToFile = function(data, fileName, properties) {
+            window.URL = window.URL || window.webkitURL;
+            var file = new File(data, fileName, properties),
+            link = document.createElement('a');
+            link.href = window.URL.createObjectURL(file);
+            link.download = fileName;
+            document.body.appendChild(link);
+            link.click();
+            window.URL.revokeObjectURL(link.href);
+            document.body.removeChild(link)
+        };
 
     });
 }());

--- a/data/markup/owl_preferences.html
+++ b/data/markup/owl_preferences.html
@@ -57,6 +57,22 @@
                         </td>
                         <td class="text-center"><button id="openSiteConfig" class="btn">Open Website Settings</button></td>
                     </tr>
+                    <tr>
+                        <td>Import Settings <br /> &emsp;
+                            <small>explanation</small>
+                        </td>
+                        <td class="text-center">
+                            <label class="btn btn-primary">
+                                <input id="importSettings" type="file" hidden>
+                            </label>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Export Settings <br /> &emsp;
+                            <small>explanation</small>
+                        </td>
+                        <td class="text-center"><button id="exportSettings" class="btn">export settings</button></td>
+                    </tr>
                 </tbody>
             </table>
         </div>

--- a/data/markup/owl_preferences.html
+++ b/data/markup/owl_preferences.html
@@ -53,26 +53,27 @@
                         <td class="text-center"><input type="checkbox" id="allowIncognito"></td>
                     </tr>
                     <tr>
+                            <td>Import Settings <br /> &emsp;
+                                <small>Import site settings from JSON file</small>
+                            </td>
+                            <td class="text-center">
+                                <label id="importSettings" class="btn">Import Settings
+                                    <input id="importSettingsInput" type="file" hidden>
+                                </label>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Export Settings <br /> &emsp;
+                                <small>Export site settings to JSON format</small>
+                            </td>
+                            <td class="text-center"><button id="exportSettings" class="btn">Export settings</button></td>
+                        </tr>
+                    <tr>
                         <td>Configure Website Preference
                         </td>
                         <td class="text-center"><button id="openSiteConfig" class="btn">Open Website Settings</button></td>
                     </tr>
-                    <tr>
-                        <td>Import Settings <br /> &emsp;
-                            <small>explanation</small>
-                        </td>
-                        <td class="text-center">
-                            <label class="btn btn-primary">
-                                <input id="importSettings" type="file" hidden>
-                            </label>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>Export Settings <br /> &emsp;
-                            <small>explanation</small>
-                        </td>
-                        <td class="text-center"><button id="exportSettings" class="btn">export settings</button></td>
-                    </tr>
+                  
                 </tbody>
             </table>
         </div>


### PR DESCRIPTION
Implemented two buttons on settings page to import/export settings. Also edited the css file in order to make them look the same as the rest of the settings page.

Export button will create a JSON file of format

`
"whiteSites:" [

],
"alwaysEnableSites": [

],
"classicSitesList":[
]
`

Import Button will take a json file of the same format, override the settings in local storage and then update the global settings values inside of background.js.  For now it overrides the settings.  If you think a merge of site settings is better, then I will implement that.   Or perhaps we could offer options for either overriding or merging.

Let me know if there are any issues.